### PR TITLE
Fix #49

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -18,14 +18,10 @@ body {
   color: var(--dyalog-body-text-color);
 }
 
-.md-typeset h1 {
-    overflow-x: auto;
-}
-
-.md-typeset h1, .md-typeset h2, .md-typeset h3, .md-typeset h4 {
+.md-typeset h2, .md-typeset h3, .md-typeset h4 {
   color: var(--dyalog-body-text-color);
 }
-.md-typeset h1 code, .md-typeset h2 code, .md-typeset h3 code, .md-typeset h4 code {
+.md-typeset h2 code, .md-typeset h3 code, .md-typeset h4 code {
     font-size: inherit;
 }
 
@@ -53,7 +49,7 @@ body {
     line-height: 1.2rem;
     background: none;
 }
-code, .command, .Dyalog {
+code, .Dyalog {
     font-family: APL;
 }
 code[class^="language-"], div[class^="language-"] pre code {
@@ -176,29 +172,32 @@ th[align="right"], td[align="right"] {
 }
 
 /* Style the heading container for the Language Reference */
-.heading {
+.md-typeset h1 {
     display: flex;
     justify-content: space-between;
     align-items: center;
     background-color: #FF6A13;
     padding: 5px 10px; /* Adjusted padding for less vertical whitespace */
     border-radius: 5px; /* Rounded corners */
-    font-size: 0.9em;
-}
+    color: white;
+    overflow-x: auto;
 
 /* Style the left-aligned name */
-.name {
-    flex-grow: 1;
-    /* Take up available space */
-    color: white;
-}
-
+    & > span:first-child {
+        flex-grow: 1;    /* Take up available space */
 /* Style the right-aligned command */
-.command {
-    text-align: right;
-    color: white;
-    font-family: APL;
-    white-space: pre;
+        & + code, & + span {
+            text-align: right;
+            white-space: pre;
+            color: inherit;
+            font-size: inherit;
+            & + a {
+                color: inherit;
+                font-variant-position: super;
+                margin-left: 0.5ex;
+            }
+        }
+    }
 }
 
 /* List styles */

--- a/css/main.css
+++ b/css/main.css
@@ -173,15 +173,20 @@ th[align="right"], td[align="right"] {
 
 /* Style the heading container for the Language Reference */
 .md-typeset h1 {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
     background-color: #FF6A13;
     padding: 5px 10px; /* Adjusted padding for less vertical whitespace */
     border-radius: 5px; /* Rounded corners */
     color: white;
     overflow-x: auto;
-
+    &:has(span) {
+        display: flex;
+        justify-content: space-between;
+    }
+    & code {
+        color: inherit;
+        font-size: 1.1em;
+        line-height: inherit;
+    }
 /* Style the left-aligned name */
     & > span:first-child {
         flex-grow: 1;    /* Take up available space */
@@ -189,8 +194,6 @@ th[align="right"], td[align="right"] {
         & + code, & + span {
             text-align: right;
             white-space: pre;
-            color: inherit;
-            font-size: inherit;
             & + a {
                 color: inherit;
                 font-variant-position: super;


### PR DESCRIPTION
It is essential that headings with right-aligned code or text use the forms:
```
# <span>Name of page</span> <span>Right-aligned</span>
# <span>Name of page</span> `right-aligned`
```
If the code uses standard notation, put `{{key}}` immediately to the right:
```
# <span>Name of page</span> `right-aligned`{{key}}
```
Page titles that have nothing special, even with inline code, use standard markdown:
```
# Page name about `code`
```

**Make sure to coordinate merging with that of https://github.com/Dyalog/documentation/compare/889-change-html-h1s-to-markdown-and-add-key-to-notation**